### PR TITLE
filled out license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -552,8 +552,8 @@ to the start of each source file to most effectively state the exclusion of warr
 and each file should have at least the “copyright” line and a pointer to
 where the full notice is found.
 
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
+    crosstalkr: Identification of functionally relevant subnetworks from high-dimensional omics data
+    Copyright (C) 2021  Davis Weaver
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -573,7 +573,7 @@ Also add information on how to contact you by electronic and paper mail.
 If the program does terminal interaction, make it output a short notice like this
 when it starts in an interactive mode:
 
-    <program>  Copyright (C) <year>  <name of author>
+    crosstalkr  Copyright (C) 2021  Davis Weaver
     This program comes with ABSOLUTELY NO WARRANTY; for details type 'show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type 'show c' for details.


### PR DESCRIPTION
Added:
* author name
* year
* software title + description

I believe tidyverse packages recently switched to MIT license for simplicity. Additionally, GPL-3 might cause issues/complexity if you're hoping to patent/commercialize results from this package. Might be worth considering a switch to MIT license.